### PR TITLE
write 200 to ctx.status

### DIFF
--- a/middleware/hotMiddleware.js
+++ b/middleware/hotMiddleware.js
@@ -8,8 +8,8 @@ export default (compiler, opts) => {
     ctx.body = stream
     await expressMiddleware(ctx.req, {
       write: stream.write.bind(stream),
-      writeHead: (state, headers) => {
-        ctx.state = state
+      writeHead: (status, headers) => {
+        ctx.status = status
         ctx.set(headers)
       }
     }, next)


### PR DESCRIPTION
The use of `ctx.state` is wrong here since `ctx.state` is the recommended namespace for user values (see http://koajs.com/#ctx-state).