### PR TITLE
fix the error of missing res.end function

### DIFF
--- a/middleware/hotMiddleware.js
+++ b/middleware/hotMiddleware.js
@@ -1,6 +1,8 @@
 import hotMiddleware from 'webpack-hot-middleware'
 import { PassThrough } from 'stream'
 
+const noop = () => {}
+
 export default (compiler, opts) => {
   const expressMiddleware = hotMiddleware(compiler, opts)
   return async (ctx, next) => {
@@ -11,7 +13,8 @@ export default (compiler, opts) => {
       writeHead: (status, headers) => {
         ctx.status = status
         ctx.set(headers)
-      }
+      },
+      res: noop
     }, next)
   }
 }

--- a/middleware/hotMiddleware.js
+++ b/middleware/hotMiddleware.js
@@ -14,7 +14,7 @@ export default (compiler, opts) => {
         ctx.status = status
         ctx.set(headers)
       },
-      res: noop
+      end: noop
     }, next)
   }
 }


### PR DESCRIPTION
"koa": "^2.5.3",
"webpack-hot-middleware": "^2.25.0",

There is a function call res.end() at line 105 in in webpack-hot-middleware/middleware.js
` 
req.on('close', function() {
    if (!res.finished) res.end();
    delete clients[id];
});
`
So the error occurs as below
<img width="1156" alt="Screen Shot 2021-04-29 at 10 54 39 AM" src="https://user-images.githubusercontent.com/15572298/116497614-61ad0d00-a8da-11eb-80f8-7f5afb50570e.png">
